### PR TITLE
Fix some problems related to shrinks

### DIFF
--- a/gen/complex.go
+++ b/gen/complex.go
@@ -51,5 +51,5 @@ func Complex64() gopter.Gen {
 	).Map(func(v interface{}) interface{} {
 		values := v.([]interface{})
 		return complex(values[0].(float32), values[1].(float32))
-	}).WithShrinker(Complex128Shrinker)
+	}).WithShrinker(Complex64Shrinker)
 }

--- a/gen/helper_test.go
+++ b/gen/helper_test.go
@@ -15,5 +15,19 @@ func commonGeneratorTest(t *testing.T, name string, gen gopter.Gen, valueCheck f
 		} else if !valueCheck(value) {
 			t.Errorf("Invalid value (%s): %#v", name, value)
 		}
+
+		genResult := gen(gopter.DefaultGenParameters())
+		if genResult.Shrinker != nil {
+			value, ok := genResult.Retrieve()
+			if !ok || value == nil {
+				t.Errorf("Invalid generator result (%s): %#v", name, value)
+			} else {
+				shrink := genResult.Shrinker(value)
+				shrunkValue, ok := shrink()
+				if ok && !valueCheck(shrunkValue) {
+					t.Errorf("Invalid shrunk value (%s): %#v", name, shrunkValue)
+				}
+			}
+		}
 	}
 }

--- a/gen/helper_test.go
+++ b/gen/helper_test.go
@@ -22,10 +22,10 @@ func commonGeneratorTest(t *testing.T, name string, gen gopter.Gen, valueCheck f
 			if !ok || value == nil {
 				t.Errorf("Invalid generator result (%s): %#v", name, value)
 			} else {
-				shrink := genResult.Shrinker(value)
+				shrink := genResult.Shrinker(value).Filter(genResult.Sieve)
 				shrunkValue, ok := shrink()
 				if ok && !valueCheck(shrunkValue) {
-					t.Errorf("Invalid shrunk value (%s): %#v", name, shrunkValue)
+					t.Errorf("Invalid shrunk value (%s): %#v -> %#v", name, value, shrunkValue)
 				}
 			}
 		}

--- a/gen/integers.go
+++ b/gen/integers.go
@@ -65,8 +65,8 @@ func Int32Range(min, max int32) gopter.Gen {
 		Map(int64To32).
 		WithShrinker(Int32Shrinker).
 		SuchThat(func(v interface{}) bool {
-			return v.(int32) >= min && v.(int32) <= max
-		})
+		return v.(int32) >= min && v.(int32) <= max
+	})
 }
 
 // UInt32Range generates uint32 numbers within a given range
@@ -75,8 +75,8 @@ func UInt32Range(min, max uint32) gopter.Gen {
 		Map(uint64To32).
 		WithShrinker(UInt32Shrinker).
 		SuchThat(func(v interface{}) bool {
-			return v.(uint32) >= min && v.(uint32) <= max
-		})
+		return v.(uint32) >= min && v.(uint32) <= max
+	})
 }
 
 // Int32 generate arbitrary int32 numbers
@@ -95,8 +95,8 @@ func Int16Range(min, max int16) gopter.Gen {
 		Map(int64To16).
 		WithShrinker(Int16Shrinker).
 		SuchThat(func(v interface{}) bool {
-			return v.(int16) >= min && v.(int16) <= max
-		})
+		return v.(int16) >= min && v.(int16) <= max
+	})
 }
 
 // UInt16Range generates uint16 numbers within a given range
@@ -105,8 +105,8 @@ func UInt16Range(min, max uint16) gopter.Gen {
 		Map(uint64To16).
 		WithShrinker(UInt16Shrinker).
 		SuchThat(func(v interface{}) bool {
-			return v.(uint16) >= min && v.(uint16) <= max
-		})
+		return v.(uint16) >= min && v.(uint16) <= max
+	})
 }
 
 // Int16 generate arbitrary int16 numbers
@@ -125,8 +125,8 @@ func Int8Range(min, max int8) gopter.Gen {
 		Map(int64To8).
 		WithShrinker(Int8Shrinker).
 		SuchThat(func(v interface{}) bool {
-			return v.(int8) >= min && v.(int8) <= max
-		})
+		return v.(int8) >= min && v.(int8) <= max
+	})
 }
 
 // UInt8Range generates uint8 numbers within a given range
@@ -135,8 +135,8 @@ func UInt8Range(min, max uint8) gopter.Gen {
 		Map(uint64To8).
 		WithShrinker(UInt8Shrinker).
 		SuchThat(func(v interface{}) bool {
-			return v.(uint8) >= min && v.(uint8) <= max
-		})
+		return v.(uint8) >= min && v.(uint8) <= max
+	})
 }
 
 // Int8 generate arbitrary int16 numbers

--- a/gen/integers.go
+++ b/gen/integers.go
@@ -12,15 +12,16 @@ func Int64Range(min, max int64) gopter.Gen {
 	if max < min {
 		return Fail(reflect.TypeOf(int64(0)))
 	}
-	d := uint64(max - min + 1)
+	rangeSize := uint64(max - min + 1)
 
-	if d == 0 { // Check overflow (i.e. max = MaxInt64, min = MinInt64)
+	if max == math.MaxInt64 && min == math.MinInt64 { // Check overflow (i.e. max = MaxInt64, min = MinInt64)
 		return func(genParams *gopter.GenParameters) *gopter.GenResult {
 			return gopter.NewGenResult(genParams.NextInt64(), Int64Shrinker)
 		}
 	}
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
-		genResult := gopter.NewGenResult(min+int64(genParams.NextUint64()%d), Int64Shrinker)
+		var nextResult uint64 = uint64(min) + (genParams.NextUint64() % rangeSize)
+		genResult := gopter.NewGenResult(int64(nextResult), Int64Shrinker)
 		genResult.Sieve = func(v interface{}) bool {
 			return v.(int64) >= min && v.(int64) <= max
 		}
@@ -31,12 +32,12 @@ func Int64Range(min, max int64) gopter.Gen {
 // UInt64Range generates uint64 numbers within a given range
 func UInt64Range(min, max uint64) gopter.Gen {
 	if max < min {
-		return Fail(reflect.TypeOf(int64(0)))
+		return Fail(reflect.TypeOf(uint64(0)))
 	}
 	d := max - min + 1
 	if d == 0 { // Check overflow (i.e. max = MaxInt64, min = MinInt64)
 		return func(genParams *gopter.GenParameters) *gopter.GenResult {
-			return gopter.NewGenResult(genParams.NextUint64(), Int64Shrinker)
+			return gopter.NewGenResult(genParams.NextUint64(), UInt64Shrinker)
 		}
 	}
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {

--- a/gen/integers.go
+++ b/gen/integers.go
@@ -12,13 +12,13 @@ func Int64Range(min, max int64) gopter.Gen {
 	if max < min {
 		return Fail(reflect.TypeOf(int64(0)))
 	}
-	rangeSize := uint64(max - min + 1)
-
-	if max == math.MaxInt64 && min == math.MinInt64 { // Check overflow (i.e. max = MaxInt64, min = MinInt64)
+	if max == math.MaxInt64 && min == math.MinInt64 { // Check for range overflow
 		return func(genParams *gopter.GenParameters) *gopter.GenResult {
 			return gopter.NewGenResult(genParams.NextInt64(), Int64Shrinker)
 		}
 	}
+
+	rangeSize := uint64(max - min + 1)
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var nextResult uint64 = uint64(min) + (genParams.NextUint64() % rangeSize)
 		genResult := gopter.NewGenResult(int64(nextResult), Int64Shrinker)

--- a/gen/integers_shrink.go
+++ b/gen/integers_shrink.go
@@ -1,6 +1,8 @@
 package gen
 
-import "github.com/leanovate/gopter"
+import (
+	"github.com/leanovate/gopter"
+)
 
 type int64Shrink struct {
 	original int64

--- a/gen/integers_test.go
+++ b/gen/integers_test.go
@@ -24,7 +24,7 @@ func TestInt64Range(t *testing.T) {
 		return ok && v > 0
 	})
 
-	commonGeneratorTest(t, "int 64 positive", gen.Int64Range(math.MinInt64, -1), func(value interface{}) bool {
+	commonGeneratorTest(t, "int 64 negative", gen.Int64Range(math.MinInt64, -1), func(value interface{}) bool {
 		v, ok := value.(int64)
 		return ok && v < 0
 	})

--- a/gen/integers_test.go
+++ b/gen/integers_test.go
@@ -28,6 +28,11 @@ func TestInt64Range(t *testing.T) {
 		v, ok := value.(int64)
 		return ok && v < 0
 	})
+
+	commonGeneratorTest(t, "full int 64 range", gen.Int64Range(math.MinInt64, math.MaxInt64), func(value interface{}) bool {
+		_, ok := value.(int64)
+		return ok
+	})
 }
 
 func TestUInt64Range(t *testing.T) {

--- a/gen/strings.go
+++ b/gen/strings.go
@@ -119,5 +119,9 @@ func genString(runeGen gopter.Gen, runeSieve func(ch rune) bool) gopter.Gen {
 			}
 		}
 		return true
-	}).WithShrinker(SliceShrinker(gopter.NoShrinker))
+	}).Map(func(v interface{}) interface{} {
+		return []rune(v.(string))
+	}).WithShrinker(SliceShrinker(gopter.NoShrinker)).Map(func(v interface{}) interface{} {
+		return string(v.([]rune))
+	})
 }

--- a/gen/strings_test.go
+++ b/gen/strings_test.go
@@ -82,7 +82,7 @@ func TestAlphaString(t *testing.T) {
 				t.Errorf("Invalid string: %#v", v)
 			}
 		}
-		if result.Sieve == nil || result.Sieve("01") {
+		if result.Sieve != nil && result.Sieve("01") {
 			t.Error("Invalid sieve")
 		}
 	}
@@ -106,7 +106,7 @@ func TestNumString(t *testing.T) {
 				t.Errorf("Invalid string: %#v", v)
 			}
 		}
-		if result.Sieve == nil || result.Sieve("abc") {
+		if result.Sieve != nil && result.Sieve("abc") {
 			t.Error("Invalid sieve")
 		}
 	}
@@ -136,7 +136,7 @@ func TestIdentifier(t *testing.T) {
 				t.Errorf("Invalid string: %#v", v)
 			}
 		}
-		if result.Sieve == nil || result.Sieve("0ab") || result.Sieve("ab\n") {
+		if result.Sieve != nil && (result.Sieve("0ab") || result.Sieve("ab\n")) {
 			t.Error("Invalid sieve")
 		}
 	}

--- a/prop/forall_test.go
+++ b/prop/forall_test.go
@@ -9,22 +9,6 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func MisimplementedConcat(a, b string) string {
-	return b
-}
-
-func TestMisimplementedConcat(t *testing.T) {
-	properties := gopter.NewProperties(nil)
-
-	properties.Property("length is sum of lengths", prop.ForAll(
-		func(a, b string) bool {
-			return MisimplementedConcat(a, b) == a+b
-		},
-		gen.AnyString(), gen.AnyString(),
-	))
-	properties.TestingRun(t)
-}
-
 func TestSqrt(t *testing.T) {
 	properties := gopter.NewProperties(nil)
 

--- a/prop/forall_test.go
+++ b/prop/forall_test.go
@@ -9,6 +9,22 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
+func MisimplementedConcat(a, b string) string {
+	return b
+}
+
+func TestMisimplementedConcat(t *testing.T) {
+	properties := gopter.NewProperties(nil)
+
+	properties.Property("length is sum of lengths", prop.ForAll(
+		func(a, b string) bool {
+			return MisimplementedConcat(a, b) == a+b
+		},
+		gen.AnyString(), gen.AnyString(),
+	))
+	properties.TestingRun(t)
+}
+
 func TestSqrt(t *testing.T) {
 	properties := gopter.NewProperties(nil)
 

--- a/shrink.go
+++ b/shrink.go
@@ -18,7 +18,7 @@ func (s Shrink) Filter(condition func(interface{}) bool) Shrink {
 	}
 }
 
-// Map creates a shrink by a appling a converter to each element of a shrink
+// Map creates a shrink by applying a converter to each element of a shrink
 func (s Shrink) Map(f func(interface{}) interface{}) Shrink {
 	return func() (interface{}, bool) {
 		value, ok := s()


### PR DESCRIPTION
This change expands `commonGeneratorTest` to include code that exercises the generator's shrinker (and sieve).  It adds the assertion that, if there is a shrinker, it must be able to shrink all the values generated and the resulting shrunk values must also satisfy the predicate given to commonGeneratorTest.

Also included are changes to fix bugs uncovered by this change:

  * Incorrect shrinker used with Complex64 generator
  * Incorrect overflow checking in Int64Range generator
  * Incorrect coercion in UInt64Range generator
  * Incompatible shrinker used with AnyString (and probably others) generator

Incidentally, some gofmt changes are included.

Branch was developed in collaboration with @itamarst (and really he did more than I did).

Thanks for Gopter!
