### PR TITLE
Add MaxSize and MinSize to GenParameters.

### DIFF
--- a/commands/actions.go
+++ b/commands/actions.go
@@ -109,9 +109,9 @@ func genSizedCommands(commands Commands, initialStateProvider func() State) gopt
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		sizedCommandsGen := gen.Const(sizedCommands{
 			state:    initialStateProvider(),
-			commands: make([]shrinkableCommand, 0, genParams.Size),
+			commands: make([]shrinkableCommand, 0, genParams.MaxSize),
 		})
-		for i := 0; i < genParams.Size; i++ {
+		for i := 0; i < genParams.MaxSize; i++ {
 			sizedCommandsGen = sizedCommandsGen.FlatMap(func(v interface{}) gopter.Gen {
 				prev := v.(sizedCommands)
 				return gen.RetryUntil(commands.GenCommand(prev.state), func(command Command) bool {

--- a/gen/frequency_test.go
+++ b/gen/frequency_test.go
@@ -17,7 +17,7 @@ func (f fixedSeed) Seed(seed int64) {}
 
 func fixedParameters(size int, fixed int64) *gopter.GenParameters {
 	return &gopter.GenParameters{
-		Size: size,
+		MaxSize: size,
 		Rng: rand.New(fixedSeed{
 			fixed: fixed,
 		}),

--- a/gen/integers.go
+++ b/gen/integers.go
@@ -183,12 +183,12 @@ func UInt() gopter.Gen {
 		WithShrinker(UIntShrinker)
 }
 
-// Size just extracts the Size field of the GenParameters.
+// Size just extracts the MaxSize field of the GenParameters.
 // This can be helpful to generate limited integer value in a more structued
 // manner.
 func Size() gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
-		return gopter.NewGenResult(genParams.Size, IntShrinker)
+		return gopter.NewGenResult(genParams.MaxSize, IntShrinker)
 	}
 }
 

--- a/gen/slice_of.go
+++ b/gen/slice_of.go
@@ -13,6 +13,10 @@ func SliceOf(elementGen gopter.Gen) gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		len := 0
 		if genParams.MaxSize > 0 || genParams.MinSize > 0 {
+			if genParams.MinSize > genParams.MaxSize {
+				panic("GenParameters.MinSize must be <= GenParameters.MaxSize")
+			}
+
 			len = genParams.Rng.Intn(genParams.MaxSize-genParams.MinSize) + genParams.MinSize
 		}
 		result, elementSieve, elementShrinker := genSlice(elementGen, genParams, len)

--- a/gen/slice_of.go
+++ b/gen/slice_of.go
@@ -7,11 +7,13 @@ import (
 )
 
 // SliceOf generates an arbitrary slice of generated elements
+// genParams.MaxSize sets an (exclusive) upper limit on the size of the slice
+// genParams.MinSize sets an (inclusive) lower limit on the size of the slice
 func SliceOf(elementGen gopter.Gen) gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		len := 0
-		if genParams.Size > 0 {
-			len = genParams.Rng.Intn(genParams.Size)
+		if genParams.MaxSize > 0 || genParams.MinSize > 0 {
+			len = genParams.Rng.Intn(genParams.MaxSize-genParams.MinSize) + genParams.MinSize
 		}
 		result, elementSieve, elementShrinker := genSlice(elementGen, genParams, len)
 

--- a/gen/slice_of_test.go
+++ b/gen/slice_of_test.go
@@ -77,6 +77,22 @@ func TestSliceOf(t *testing.T) {
 	}
 }
 
+func TestSliceOfPanic(t *testing.T) {
+	genParams := gopter.DefaultGenParameters()
+	genParams.MaxSize = 0
+	genParams.MinSize = 1
+	elementGen := gen.Const("element")
+	sliceGen := gen.SliceOf(elementGen)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("SliceOf did not panic when MinSize was > MaxSize")
+		}
+	}()
+
+	sliceGen(genParams).Retrieve()
+}
+
 func TestSliceOfN(t *testing.T) {
 	elementGen := gen.Const("element")
 	sliceGen := gen.SliceOfN(10, elementGen)

--- a/gen/slice_of_test.go
+++ b/gen/slice_of_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSliceOf(t *testing.T) {
 	genParams := gopter.DefaultGenParameters()
-	genParams.Size = 50
+	genParams.MaxSize = 50
 	elementGen := gen.Const("element")
 	sliceGen := gen.SliceOf(elementGen)
 
@@ -23,7 +23,7 @@ func TestSliceOf(t *testing.T) {
 		if !ok {
 			t.Errorf("Sample not slice of string: %#v", sample)
 		} else {
-			if len(strings) >= 50 {
+			if len(strings) > 50 {
 				t.Errorf("Sample has invalid length: %#v", len(strings))
 			}
 			for _, str := range strings {
@@ -34,7 +34,31 @@ func TestSliceOf(t *testing.T) {
 		}
 	}
 
-	genParams.Size = 0
+	genParams.MinSize = 10
+
+	for i := 0; i < 100; i++ {
+		sample, ok := sliceGen(genParams).Retrieve()
+
+		if !ok {
+			t.Error("Sample was not ok")
+		}
+		strings, ok := sample.([]string)
+		if !ok {
+			t.Errorf("Sample not slice of string: %#v", sample)
+		} else {
+			if len(strings) > 50 || len(strings) < 10 {
+				t.Errorf("Sample has invalid length: %#v", len(strings))
+			}
+			for _, str := range strings {
+				if str != "element" {
+					t.Errorf("Sample contains invalid value: %#v", sample)
+				}
+			}
+		}
+	}
+
+	genParams.MaxSize = 0
+	genParams.MinSize = 0
 
 	for i := 0; i < 100; i++ {
 		sample, ok := sliceGen(genParams).Retrieve()

--- a/gen_parameter_test.go
+++ b/gen_parameter_test.go
@@ -16,8 +16,8 @@ func (f *fixedSeed) Seed(seed int64) { f.fixed = seed }
 
 func TestGenParameters(t *testing.T) {
 	parameters := &gopter.GenParameters{
-		Size: 100,
-		Rng:  rand.New(&fixedSeed{}),
+		MaxSize: 100,
+		Rng:     rand.New(&fixedSeed{}),
 	}
 
 	if !parameters.NextBool() {

--- a/gen_parameters.go
+++ b/gen_parameters.go
@@ -7,7 +7,8 @@ import (
 
 // GenParameters encapsulates the parameters for all generators.
 type GenParameters struct {
-	Size           int
+	MinSize        int
+	MaxSize        int
 	MaxShrinkCount int
 	Rng            *rand.Rand
 }
@@ -16,7 +17,7 @@ type GenParameters struct {
 // generated slices or strings.
 func (p *GenParameters) WithSize(size int) *GenParameters {
 	newParameters := *p
-	newParameters.Size = size
+	newParameters.MaxSize = size
 	return &newParameters
 }
 
@@ -47,7 +48,8 @@ func (p *GenParameters) NextUint64() uint64 {
 // seed)
 func (p *GenParameters) CloneWithSeed(seed int64) *GenParameters {
 	return &GenParameters{
-		Size:           p.Size,
+		MinSize:        p.MinSize,
+		MaxSize:        p.MaxSize,
 		MaxShrinkCount: p.MaxShrinkCount,
 		Rng:            rand.New(rand.NewSource(seed)),
 	}
@@ -58,7 +60,8 @@ func DefaultGenParameters() *GenParameters {
 	seed := time.Now().UnixNano()
 
 	return &GenParameters{
-		Size:           100,
+		MinSize:        0,
+		MaxSize:        100,
 		MaxShrinkCount: 1000,
 		Rng:            rand.New(rand.NewSource(seed)),
 	}

--- a/prop.go
+++ b/prop.go
@@ -31,7 +31,8 @@ func (prop Prop) Check(parameters *TestParameters) *TestResult {
 	sizeStep := float64(parameters.MaxSize-parameters.MinSize) / (iterations * float64(parameters.Workers))
 
 	genParameters := GenParameters{
-		Size:           parameters.MinSize,
+		MinSize:        parameters.MinSize,
+		MaxSize:        parameters.MaxSize,
 		MaxShrinkCount: parameters.MaxShrinkCount,
 		Rng:            parameters.Rng,
 	}

--- a/prop_test.go
+++ b/prop_test.go
@@ -46,7 +46,7 @@ func TestPropMaxDiscardRatio(t *testing.T) {
 	prop := Prop(func(genParams *GenParameters) *PropResult {
 		atomic.AddInt64(&called, 1)
 
-		if genParams.Size > 21 {
+		if genParams.MaxSize > 21 {
 			return &PropResult{
 				Status: PropTrue,
 			}

--- a/test_parameters.go
+++ b/test_parameters.go
@@ -8,12 +8,14 @@ import (
 // TestParameters to run property tests
 type TestParameters struct {
 	MinSuccessfulTests int
-	MinSize            int
-	MaxSize            int
-	MaxShrinkCount     int
-	Rng                *rand.Rand
-	Workers            int
-	MaxDiscardRatio    float64
+	// MinSize is an (inclusive) lower limit on the size of the parameters
+	MinSize int
+	// MaxSize is an (exclusive) upper limit on the size of the parameters
+	MaxSize         int
+	MaxShrinkCount  int
+	Rng             *rand.Rand
+	Workers         int
+	MaxDiscardRatio float64
 }
 
 // DefaultTestParameters creates reasonable default Parameters for most cases


### PR DESCRIPTION
Fixes #11 

This allows configuring the max and min size of a slice. Instances of genParams.Size have been replaced with genParams.MaxSize, which is consistent with current use.

Tests have been added to check that MinSize and MaxSize behave as expected for the SliceOf generator.