### PR TITLE
Fix panic when MinSize == MaxSize

### DIFF
--- a/gen/slice_of.go
+++ b/gen/slice_of.go
@@ -17,7 +17,11 @@ func SliceOf(elementGen gopter.Gen) gopter.Gen {
 				panic("GenParameters.MinSize must be <= GenParameters.MaxSize")
 			}
 
-			len = genParams.Rng.Intn(genParams.MaxSize-genParams.MinSize) + genParams.MinSize
+			if genParams.MaxSize == genParams.MinSize {
+				len = genParams.MaxSize
+			} else {
+				len = genParams.Rng.Intn(genParams.MaxSize-genParams.MinSize) + genParams.MinSize
+			}
 		}
 		result, elementSieve, elementShrinker := genSlice(elementGen, genParams, len)
 

--- a/gen/slice_of_test.go
+++ b/gen/slice_of_test.go
@@ -57,6 +57,29 @@ func TestSliceOf(t *testing.T) {
 		}
 	}
 
+	genParams.MaxSize = 10
+
+	for i := 0; i < 100; i++ {
+		sample, ok := sliceGen(genParams).Retrieve()
+
+		if !ok {
+			t.Error("Sample was not ok")
+		}
+		strings, ok := sample.([]string)
+		if !ok {
+			t.Errorf("Sample not slice of string: %#v", sample)
+		} else {
+			if len(strings) != 10 {
+				t.Errorf("Sample has invalid length: %#v", len(strings))
+			}
+			for _, str := range strings {
+				if str != "element" {
+					t.Errorf("Sample contains invalid value: %#v", sample)
+				}
+			}
+		}
+	}
+
 	genParams.MaxSize = 0
 	genParams.MinSize = 0
 


### PR DESCRIPTION
This was a slight oversight in my last pull request, Intn panics for negative *and* zero values.
This ensures MaxSize - MinSize should always be >= 1.