### PR TITLE
Improve performance of Map, SuchThat and DeriveGen - #29

### DIFF
--- a/derived_gen.go
+++ b/derived_gen.go
@@ -106,7 +106,7 @@ func DeriveGen(downstream interface{}, upstream interface{}, gens ...Gen) Gen {
 	sieves := make([]func(interface{}) bool, len(gens))
 	shrinkers := make([]Shrinker, len(gens))
 	for i, gen := range gens {
-		result := gen(DefaultGenParameters())
+		result := gen(DefaultGenParams)
 		sieves[i] = result.Sieve
 		shrinkers[i] = result.Shrinker
 	}

--- a/gen.go
+++ b/gen.go
@@ -16,6 +16,10 @@ import (
 // If you just plug generators together you do not have to worry about this.
 type Gen func(*GenParameters) *GenResult
 
+var (
+	DefaultGenParams = DefaultGenParameters()
+)
+
 // Sample generate a sample value.
 // Depending on the state of the RNG the generate might fail to provide a sample
 func (g Gen) Sample() (interface{}, bool) {
@@ -48,7 +52,7 @@ func (g Gen) SuchThat(f interface{}) Gen {
 	if checkType.NumIn() != 1 {
 		panic(fmt.Sprintf("Param of SuchThat has to be a func with one param, but is %v", checkType.NumIn()))
 	} else {
-		genResultType := g(DefaultGenParameters()).ResultType
+		genResultType := g(DefaultGenParams).ResultType
 		if !genResultType.AssignableTo(checkType.In(0)) {
 			panic(fmt.Sprintf("Param of SuchThat has to be a func with one param assignable to %v, but is %v", genResultType, checkType.In(0)))
 		}
@@ -102,7 +106,7 @@ func (g Gen) Map(f interface{}) Gen {
 	if mapperType.NumIn() != 1 {
 		panic(fmt.Sprintf("Param of Map has to be a func with one param, but is %v", mapperType.NumIn()))
 	} else {
-		genResultType := g(DefaultGenParameters()).ResultType
+		genResultType := g(DefaultGenParams).ResultType
 		if !genResultType.AssignableTo(mapperType.In(0)) {
 			panic(fmt.Sprintf("Param of Map has to be a func with one param assignable to %v, but is %v", genResultType, mapperType.In(0)))
 		}

--- a/gen_test.go
+++ b/gen_test.go
@@ -22,6 +22,32 @@ func TestGenSample(t *testing.T) {
 	}
 }
 
+func BenchmarkMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gen := constGen("sample")
+		var mappedWith string
+		mapper := func(v string) string {
+			mappedWith = v
+			return "other"
+		}
+		value, ok := gen.Map(mapper).Sample()
+		if !ok || value != "other" {
+			b.Errorf("Invalid gen sample: %#v", value)
+		}
+		if mappedWith != "sample" {
+			b.Errorf("Invalid mapped with: %#v", mappedWith)
+		}
+
+		gen = gen.SuchThat(func(interface{}) bool {
+			return false
+		})
+		value, ok = gen.Map(mapper).Sample()
+		if ok {
+			b.Errorf("Invalid gen sample: %#v", value)
+		}
+	}
+}
+
 func TestGenMap(t *testing.T) {
 	gen := constGen("sample")
 	var mappedWith string


### PR DESCRIPTION
I run some benchmarks for comparison, basically I cloned `TestGenMap` test and changed it for benchmarking. Here are the results
### Before 
go test -benchmem -run=github.com/leanovate/gopter -bench BenchmarkMap
goos: darwin
goarch: amd64
pkg: github.com/leanovate/gopter
BenchmarkMap-8             **30000             54663 ns/op           28240 B/op         34 allocs/op**
PASS
ok      github.com/leanovate/gopter     2.183s
### After
go test -benchmem -run=github.com/leanovate/gopter -bench BenchmarkMap
goos: darwin
goarch: amd64
pkg: github.com/leanovate/gopter
BenchmarkMap-8            **100000             22058 ns/op           11872 B/op         25 allocs/op**
PASS
ok      github.com/leanovate/gopter     2.451s

This is a PR for #29 