### PR TITLE
Log initial seed upon test failure

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -48,6 +48,6 @@ func (p *Properties) Run(reporter Reporter) bool {
 // This the preferred wait to run property tests as part of a go unit test.
 func (p *Properties) TestingRun(t *testing.T) {
 	if !p.Run(ConsoleReporter(true)) {
-		t.Fail()
+		t.Errorf("failed with initial seed: %d", p.parameters.Seed)
 	}
 }

--- a/test_parameters.go
+++ b/test_parameters.go
@@ -13,6 +13,7 @@ type TestParameters struct {
 	// MaxSize is an (exclusive) upper limit on the size of the parameters
 	MaxSize         int
 	MaxShrinkCount  int
+	Seed            int64
 	Rng             *rand.Rand
 	Workers         int
 	MaxDiscardRatio float64
@@ -27,6 +28,7 @@ func DefaultTestParameters() *TestParameters {
 		MinSize:            0,
 		MaxSize:            100,
 		MaxShrinkCount:     1000,
+		Seed:               seed,
 		Rng:                rand.New(rand.NewSource(seed)),
 		Workers:            1,
 		MaxDiscardRatio:    5,


### PR DESCRIPTION
Possible way to address one of the issues in https://github.com/leanovate/gopter/issues/31 