### PR TITLE
Add ability to override type generated in gen.SliceOf(...)

### DIFF
--- a/gen/slice_of.go
+++ b/gen/slice_of.go
@@ -9,7 +9,13 @@ import (
 // SliceOf generates an arbitrary slice of generated elements
 // genParams.MaxSize sets an (exclusive) upper limit on the size of the slice
 // genParams.MinSize sets an (inclusive) lower limit on the size of the slice
-func SliceOf(elementGen gopter.Gen) gopter.Gen {
+func SliceOf(elementGen gopter.Gen, typeOverrides ...reflect.Type) gopter.Gen {
+	var typeOverride reflect.Type
+	if len(typeOverrides) > 1 {
+		panic("too many type overrides specified, at most 1 may be provided.")
+	} else if len(typeOverrides) == 1 {
+		typeOverride = typeOverrides[0]
+	}
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		len := 0
 		if genParams.MaxSize > 0 || genParams.MinSize > 0 {
@@ -23,7 +29,7 @@ func SliceOf(elementGen gopter.Gen) gopter.Gen {
 				len = genParams.Rng.Intn(genParams.MaxSize-genParams.MinSize) + genParams.MinSize
 			}
 		}
-		result, elementSieve, elementShrinker := genSlice(elementGen, genParams, len)
+		result, elementSieve, elementShrinker := genSlice(elementGen, genParams, len, typeOverride)
 
 		genResult := gopter.NewGenResult(result.Interface(), SliceShrinker(elementShrinker))
 		if elementSieve != nil {
@@ -34,38 +40,49 @@ func SliceOf(elementGen gopter.Gen) gopter.Gen {
 }
 
 // SliceOfN generates a slice of generated elements with definied length
-func SliceOfN(len int, elementGen gopter.Gen) gopter.Gen {
+func SliceOfN(l int, elementGen gopter.Gen, typeOverrides ...reflect.Type) gopter.Gen {
+	var typeOverride reflect.Type
+	if len(typeOverrides) > 1 {
+		panic("too many type overrides specified, at most 1 may be provided.")
+	} else if len(typeOverrides) == 1 {
+		typeOverride = typeOverrides[0]
+	}
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
-		result, elementSieve, elementShrinker := genSlice(elementGen, genParams, len)
+		result, elementSieve, elementShrinker := genSlice(elementGen, genParams, l, typeOverride)
 
 		genResult := gopter.NewGenResult(result.Interface(), SliceShrinkerOne(elementShrinker))
 		if elementSieve != nil {
 			genResult.Sieve = func(v interface{}) bool {
 				rv := reflect.ValueOf(v)
-				return rv.Len() == len && forAllSieve(elementSieve)(v)
+				return rv.Len() == l && forAllSieve(elementSieve)(v)
 			}
 		} else {
 			genResult.Sieve = func(v interface{}) bool {
-				return reflect.ValueOf(v).Len() == len
+				return reflect.ValueOf(v).Len() == l
 			}
 		}
 		return genResult
 	}
 }
 
-func genSlice(elementGen gopter.Gen, genParams *gopter.GenParameters, len int) (reflect.Value, func(interface{}) bool, gopter.Shrinker) {
+func genSlice(elementGen gopter.Gen, genParams *gopter.GenParameters, len int, typeOverride reflect.Type) (reflect.Value, func(interface{}) bool, gopter.Shrinker) {
 	element := elementGen(genParams)
 	elementSieve := element.Sieve
 	elementShrinker := element.Shrinker
 
-	result := reflect.MakeSlice(reflect.SliceOf(element.ResultType), 0, len)
+	sliceType := typeOverride
+	if sliceType == nil {
+		sliceType = element.ResultType
+	}
+
+	result := reflect.MakeSlice(reflect.SliceOf(sliceType), 0, len)
 
 	for i := 0; i < len; i++ {
 		value, ok := element.Retrieve()
 
 		if ok {
 			if value == nil {
-				result = reflect.Append(result, reflect.Zero(element.ResultType))
+				result = reflect.Append(result, reflect.Zero(sliceType))
 			} else {
 				result = reflect.Append(result, reflect.ValueOf(value))
 			}

--- a/gen/slice_of_test.go
+++ b/gen/slice_of_test.go
@@ -1,6 +1,7 @@
 package gen_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/leanovate/gopter"
@@ -170,3 +171,27 @@ func TestSliceOfNSieve(t *testing.T) {
 		t.Error("Sieve must not allow array with invalid element")
 	}
 }
+
+func TestSliceOfOverride(t *testing.T) {
+	genParams := gopter.DefaultGenParameters()
+	genParams.MaxSize = 50
+	sliceType := reflect.TypeOf((*baseType)(nil)).Elem()
+	sliceGen := gen.SliceOf(gen.OneGenOf(genA(), genB()), sliceType)
+	result := sliceGen(gopter.DefaultGenParameters())
+	value, ok := result.Retrieve()
+	if !ok || value == nil {
+		t.Errorf("Invalid value: %#v", value)
+	}
+}
+
+type baseType interface {
+	String() string
+}
+
+type specA struct{}
+type specB struct{}
+
+func (a specA) String() string { return "specA" }
+func (b specB) String() string { return "specB" }
+func genA() gopter.Gen         { return gen.Const(specA{}) }
+func genB() gopter.Gen         { return gen.Const(specB{}) }


### PR DESCRIPTION
I have a situation where I need to override the type of the slice generated when using `gen.SliceOf`:
 - I have a base interface `A` which different structs (`X` & `Y`) implement 
 - I have a generator for each of the structs, `genX` and `genY`

I'd like to use to `gen.SliceOf(gen.OneOf(genX(), genY()))` to generate a `[]A`, to do so I have to provide an override for the type to `SliceOf`. This PR adds this functionality. 