### PR TITLE
Avoid nil reference when struct has gen.PtrOf field

### DIFF
--- a/gen/struct.go
+++ b/gen/struct.go
@@ -29,7 +29,11 @@ func Struct(rt reflect.Type, gens map[string]gopter.Gen) gopter.Gen {
 			if !ok {
 				return gopter.NewEmptyResult(rt)
 			}
-			result.Elem().FieldByIndex(field.Index).Set(reflect.ValueOf(value))
+			if value == nil {
+				result.Elem().FieldByIndex(field.Index).Set(reflect.Zero(field.Type))
+			} else {
+				result.Elem().FieldByIndex(field.Index).Set(reflect.ValueOf(value))
+			}
 		}
 
 		return gopter.NewGenResult(reflect.Indirect(result).Interface(), gopter.NoShrinker)

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -13,6 +13,7 @@ type testStruct struct {
 	Value2 int64
 	Value3 []int8
 	Value4 string
+	Value5 *string
 }
 
 func TestStruct(t *testing.T) {
@@ -21,6 +22,7 @@ func TestStruct(t *testing.T) {
 		"Value2":   gen.Int64(),
 		"Value3":   gen.SliceOf(gen.Int8()),
 		"NotThere": gen.AnyString(),
+		"Value5": gen.PtrOf(gen.Const("v5")),
 	})
 	for i := 0; i < 100; i++ {
 		value, ok := structGen.Sample()
@@ -29,7 +31,7 @@ func TestStruct(t *testing.T) {
 			t.Errorf("Invalid value: %#v", value)
 		}
 		v, ok := value.(testStruct)
-		if !ok || v.Value1 == "" || v.Value3 == nil || v.Value4 != "" {
+		if !ok || v.Value1 == "" || v.Value3 == nil || v.Value4 != "" || !(v.Value5 == nil || *v.Value5  == "v5"){
 			t.Errorf("Invalid value: %#v", value)
 		}
 	}


### PR DESCRIPTION
Hi, this library looks so cool. Thanks for your efforts. I want to start using in my project but I found a bug while trial.

Panic sometimes occurs when struct generator has a field of PtrOf generator. It sometime generates nil value but struct generator tries to retrieve value via `reflect.ValueOf()`.
When nil field is generated it should be set Zero value.