### PR TITLE
Improve docstring for PtrOf generator

### DIFF
--- a/gen/ptr_of.go
+++ b/gen/ptr_of.go
@@ -6,7 +6,7 @@ import (
 	"github.com/leanovate/gopter"
 )
 
-// PtrOf generates a pointer to a generated element
+// PtrOf generates either a pointer to a generated element or a nil pointer
 func PtrOf(elementGen gopter.Gen) gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		element := elementGen(genParams)


### PR DESCRIPTION
Documentation for PtrOf is misleading since it doesn't mention the possibility that gopter will throw away the generated value and return a nil pointer instead.