### PR TITLE
Allow gen.Struct() with interface-type fields

### DIFF
--- a/gen/struct.go
+++ b/gen/struct.go
@@ -49,7 +49,11 @@ func Struct(rt reflect.Type, gens map[string]gopter.Gen) gopter.Gen {
 			if _, ok := gens[rt.Field(i).Name]; !ok {
 				continue
 			}
-			results = append(results, s.Field(i))
+			val := s.Field(i)
+			if val.Kind() == reflect.Interface {
+				val = val.Elem()
+			}
+			results = append(results, val)
 		}
 		return results
 	})

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -14,6 +14,7 @@ type testStruct struct {
 	Value3 []int8
 	Value4 string
 	Value5 *string
+	Value6 interface{}
 }
 
 func TestStruct(t *testing.T) {
@@ -23,6 +24,7 @@ func TestStruct(t *testing.T) {
 		"Value3":   gen.SliceOf(gen.Int8()),
 		"NotThere": gen.AnyString(),
 		"Value5":   gen.PtrOf(gen.Const("v5")),
+		"Value6":   gen.AnyString(),
 	})
 	for i := 0; i < 100; i++ {
 		value, ok := structGen.Sample()


### PR DESCRIPTION
Fixes #54.

When generating a struct that has interface-type fields, the code was
causing panics in (*BiMapper).ConvertUp.  This was because Struct()
returns a DeriveGen() but the unbuildStructFunc fed into it just returns
the reflect.Value from each field.  When this is of interface type, it
doesn't fit the underlying generator type and you get a panic of the
pattern:

    panic: reflect: function created by MakeFunc using closure returned wrong type: have interface {} for string

The solution is: for interface field types, we return the underlying
element in the interface type.  This should always be safe because the
only things we're converting up were generated by ConvertDown in the
first place, so the concrete types should match.  In other words, if we
always put in an AnyString() to an interface{} field type, we'll always
get a string out of it again.