### PR TITLE
Keep Shrinker/Sieve if the in and out types of Map are the same

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -170,8 +170,13 @@ func (g Gen) Map(f interface{}) Gen {
 			if mapperType.In(0) == mapperType.Out(0) {
 				shrinker = result.Shrinker
 			}
+			var sieve func(interface{}) bool
+			if mapperType.In(0) == mapperType.Out(0) {
+				sieve = result.Sieve
+			}
 			return &GenResult{
 				Shrinker:   shrinker,
+				Sieve:   	sieve,
 				Result:     mapped.Interface(),
 				Labels:     result.Labels,
 				ResultType: mapperType.Out(0),

--- a/gen.go
+++ b/gen.go
@@ -170,13 +170,8 @@ func (g Gen) Map(f interface{}) Gen {
 			if mapperType.In(0) == mapperType.Out(0) {
 				shrinker = result.Shrinker
 			}
-			var sieve func(interface{}) bool
-			if mapperType.In(0) == mapperType.Out(0) {
-				sieve = result.Sieve
-			}
 			return &GenResult{
 				Shrinker:   shrinker,
-				Sieve:   	sieve,
 				Result:     mapped.Interface(),
 				Labels:     result.Labels,
 				ResultType: mapperType.Out(0),

--- a/gen_test.go
+++ b/gen_test.go
@@ -386,7 +386,7 @@ func TestWithShrinker(t *testing.T) {
 	}
 	result.Shrinker(value)
 	if shrinkerArg != "other" {
-		t.Errorf("Shrinker was lost during Map: %#v", shrinkerArg)
+		t.Errorf("Shrinker was lost during Map when the in and out types were the same")
 	}
 }
 

--- a/gen_test.go
+++ b/gen_test.go
@@ -375,6 +375,19 @@ func TestWithShrinker(t *testing.T) {
 	if shrinkerArg != "sample" {
 		t.Errorf("Invalid shrinkerArg: %#v", shrinkerArg)
 	}
+
+	mapper := func(v string) string {
+		return "other"
+	}
+	result = gen.Map(mapper)(gopter.DefaultGenParameters())
+	value, ok = result.Retrieve()
+	if !ok {
+		t.Errorf("Invalid combined value: %#v", value)
+	}
+	result.Shrinker(value)
+	if shrinkerArg != "other" {
+		t.Errorf("Shrinker was lost during Map: %#v", shrinkerArg)
+	}
 }
 
 func expectPanic(t *testing.T, expected string) {

--- a/gen_test.go
+++ b/gen_test.go
@@ -379,7 +379,10 @@ func TestWithShrinker(t *testing.T) {
 	mapper := func(v string) string {
 		return "other"
 	}
-	result = gen.Map(mapper)(gopter.DefaultGenParameters())
+	sieve := func(v string) bool {
+		return true
+	}
+	result = gen.SuchThat(sieve).Map(mapper)(gopter.DefaultGenParameters())
 	value, ok = result.Retrieve()
 	if !ok {
 		t.Errorf("Invalid combined value: %#v", value)
@@ -387,6 +390,9 @@ func TestWithShrinker(t *testing.T) {
 	result.Shrinker(value)
 	if shrinkerArg != "other" {
 		t.Errorf("Shrinker was lost during Map when the in and out types were the same")
+	}
+	if result.Sieve == nil {
+		t.Errorf("Sieve was lost during Map when the in and out types were the same")
 	}
 }
 

--- a/gen_test.go
+++ b/gen_test.go
@@ -379,10 +379,7 @@ func TestWithShrinker(t *testing.T) {
 	mapper := func(v string) string {
 		return "other"
 	}
-	sieve := func(v string) bool {
-		return true
-	}
-	result = gen.SuchThat(sieve).Map(mapper)(gopter.DefaultGenParameters())
+	result = gen.Map(mapper)(gopter.DefaultGenParameters())
 	value, ok = result.Retrieve()
 	if !ok {
 		t.Errorf("Invalid combined value: %#v", value)
@@ -390,9 +387,6 @@ func TestWithShrinker(t *testing.T) {
 	result.Shrinker(value)
 	if shrinkerArg != "other" {
 		t.Errorf("Shrinker was lost during Map when the in and out types were the same")
-	}
-	if result.Sieve == nil {
-		t.Errorf("Sieve was lost during Map when the in and out types were the same")
 	}
 }
 


### PR DESCRIPTION
There's no reason to lose the Shrinker if the types don't change.