### PR TITLE
Ignore unassignable fields in structs.

### DIFF
--- a/gen/struct.go
+++ b/gen/struct.go
@@ -19,8 +19,13 @@ func Struct(rt reflect.Type, gens map[string]gopter.Gen) gopter.Gen {
 	}
 	fieldGens := []gopter.Gen{}
 	fieldTypes := []reflect.Type{}
+	assignable := reflect.New(rt).Elem()
 	for i := 0; i < rt.NumField(); i++ {
 		fieldName := rt.Field(i).Name
+		if !assignable.Field(i).CanSet() {
+			continue
+		}
+
 		gen := gens[fieldName]
 		if gen != nil {
 			fieldGens = append(fieldGens, gen)
@@ -37,6 +42,9 @@ func Struct(rt reflect.Type, gens map[string]gopter.Gen) gopter.Gen {
 			if _, ok := gens[rt.Field(i).Name]; !ok {
 				continue
 			}
+			if !assignable.Field(i).CanSet() {
+				continue
+			}
 			result.Elem().Field(i).Set(args[0])
 			args = args[1:]
 		}
@@ -47,6 +55,9 @@ func Struct(rt reflect.Type, gens map[string]gopter.Gen) gopter.Gen {
 		results := []reflect.Value{}
 		for i := 0; i < s.NumField(); i++ {
 			if _, ok := gens[rt.Field(i).Name]; !ok {
+				continue
+			}
+			if !assignable.Field(i).CanSet() {
 				continue
 			}
 			results = append(results, s.Field(i))

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -15,6 +15,7 @@ type testStruct struct {
 	Value4 string
 	Value5 *string
 	Value6 interface{}
+	value7 string
 }
 
 func TestStruct(t *testing.T) {
@@ -25,6 +26,7 @@ func TestStruct(t *testing.T) {
 		"NotThere": gen.AnyString(),
 		"Value5":   gen.PtrOf(gen.Const("v5")),
 		"Value6":   gen.AnyString(),
+		"value7":   gen.AnyString(),
 	})
 	for i := 0; i < 100; i++ {
 		value, ok := structGen.Sample()


### PR DESCRIPTION
We have some structs which have unassignable fields. Without this change, using gopter fails with

```
panic: reflect: reflect.flag.mustBeAssignable using value obtained using unexported field [recovered]
        panic: reflect: reflect.flag.mustBeAssignable using value obtained using unexported field
```