### PR TITLE
Add StrictStruct/StrictStructPtr.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/leanovate/gopter
 
 go 1.12
+
+require github.com/pkg/errors v0.9.1


### PR DESCRIPTION
These behave the same as Struct/StructPtr, except that they panic unless the
keys in the `gens` map exactly match the fields on `rt` (i.e. gens must specify
generators for all fields.)

If passed an extra `true` argument, they allow `gens` to leave generators for
some fields unspecified. They still panic unless the keys in gens all correspond
to fields on `rt`. In this case, the generated values will have the zero value
for any field which is left unspecified in `gens`.