### PR TITLE
PickN(slice, number) and Shuffle(slice) generators

### DIFF
--- a/gen/pick_n.go
+++ b/gen/pick_n.go
@@ -1,0 +1,66 @@
+package gen
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/leanovate/gopter"
+)
+
+// PickN takes a slice and a number, and returns a generator that produces
+// subsets of exactly n items in their original order, randomly selected without duplicates
+// Example: PickN([]int{1,2,3,4,5}, 3) might produce []int{1,3,5} or []int{2,4,5}
+// Note: This generator has no shrinker. Use small slices to keep failing test feedback readable.
+func PickN(items interface{}, number int) gopter.Gen {
+	itemsVal := reflect.ValueOf(items)
+	if itemsVal.Kind() != reflect.Slice {
+		panic("PickN requires a slice")
+	}
+
+	length := itemsVal.Len()
+
+	if number <= 0 || length == 0 {
+		return Const(reflect.MakeSlice(itemsVal.Type(), 0, 0).Interface())
+	}
+
+	if number >= length {
+		return Const(items)
+	}
+
+	sliceType := itemsVal.Type()
+
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		available := make([]int, length)
+		for i := range available {
+			available[i] = i
+		}
+
+		selected := make([]int, number)
+		usedMask := make([]bool, length)
+		for i := 0; i < number; i++ {
+			pickIdx := genParams.Rng.Intn(length - i)
+			count := 0
+			actualIdx := -1
+			for j := 0; j < length; j++ {
+				if !usedMask[j] && count == pickIdx {
+					actualIdx = j
+					usedMask[j] = true
+					break
+				}
+				if !usedMask[j] {
+					count++
+				}
+			}
+			selected[i] = actualIdx
+		}
+
+		sort.Ints(selected)
+
+		result := reflect.MakeSlice(sliceType, number, number)
+		for i, idx := range selected {
+			result.Index(i).Set(itemsVal.Index(idx))
+		}
+
+		return gopter.NewGenResult(result.Interface(), gopter.NoShrinker)
+	}
+}

--- a/gen/pick_n_test.go
+++ b/gen/pick_n_test.go
@@ -1,0 +1,155 @@
+package gen_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/leanovate/gopter/gen"
+)
+
+func TestPickNDeterministic(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5}
+	pickGen := gen.PickN(items, 3)
+
+	for seed := int64(0); seed < 100; seed++ {
+		params1 := fixedParameters(10, seed)
+		params2 := fixedParameters(10, seed)
+
+		result, ok := pickGen(params1).Retrieve()
+		if !ok {
+			t.Fatalf("Sample failed for seed %d", seed)
+		}
+		result1Slice, ok := result.([]int)
+		if !ok {
+			t.Fatalf("Result 1 not slice for seed %d: %#v", seed, result)
+		}
+
+		result, ok = pickGen(params2).Retrieve()
+		if !ok {
+			t.Fatalf("Sample failed for seed %d", seed)
+		}
+		result2Slice, ok := result.([]int)
+		if !ok {
+			t.Fatalf("Result 2 not slice for seed %d: %#v", seed, result)
+		}
+
+		if !reflect.DeepEqual(result1Slice, result2Slice) {
+			t.Errorf("Same seed produced different results for seed %d:\nSeed %d result 1: %v\nSeed %d result 2: %v", seed, seed, result1Slice, seed, result2Slice)
+		}
+	}
+}
+
+func TestPickN(t *testing.T) {
+	items := []int{4, 2, 3, 5, 9, 1, 6, 8, 7}
+	pickGen := gen.PickN(items, 5)
+
+	for i := 0; i < 100; i++ {
+		value, ok := pickGen.Sample()
+		if !ok {
+			t.Error("Sample was not ok")
+			continue
+		}
+
+		result, ok := value.([]int)
+		if !ok {
+			t.Errorf("Sample not slice of int: %#v", value)
+			continue
+		}
+
+		if len(result) != 5 {
+			t.Errorf("Expected length 5, got %d: %v", len(result), result)
+			continue
+		}
+
+		for _, item := range result {
+			if !intSliceContains(items, item) {
+				t.Errorf("Result contains item not in original: %d (result: %v, original: %v)", item, result, items)
+				break
+			}
+		}
+
+		lastIndex := -1
+		for _, item := range result {
+			currentIndex := intSliceIndex(items, item)
+			if currentIndex == -1 {
+				t.Errorf("Result item not found in original: %d", item)
+				break
+			}
+			if currentIndex <= lastIndex {
+				t.Errorf("Result not in original order: item %d at index %d should come after previous item at index %d (result: %v)",
+					item, currentIndex, lastIndex, result)
+				break
+			}
+			lastIndex = currentIndex
+		}
+	}
+}
+
+func TestPickNZero(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5}
+	commonGeneratorTest(t, "pick n zero", gen.PickN(items, 0), func(value interface{}) bool {
+		result, ok := value.([]int)
+		return ok && len(result) == 0
+	})
+}
+
+func TestPickNFromEmpty(t *testing.T) {
+	commonGeneratorTest(t, "pick n from empty", gen.PickN([]int{}, 5), func(value interface{}) bool {
+		result, ok := value.([]int)
+		return ok && len(result) == 0
+	})
+}
+
+func TestPickNMoreThanAvailable(t *testing.T) {
+	items := []int{1, 2, 3}
+	commonGeneratorTest(t, "pick n more than available", gen.PickN(items, 10), func(value interface{}) bool {
+		result, ok := value.([]int)
+		return ok && reflect.DeepEqual(result, items)
+	})
+}
+
+func TestPickNVariety(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	gen := gen.PickN(items, 5)
+
+	first, ok := gen.Sample()
+	if !ok {
+		t.Fatal("First sample failed")
+	}
+	firstSlice := first.([]int)
+
+	foundDifferent := false
+	for i := 0; i < 10; i++ {
+		sample, ok := gen.Sample()
+		if !ok {
+			t.Fatal("Sample failed")
+		}
+		slice := sample.([]int)
+		if !reflect.DeepEqual(slice, firstSlice) {
+			foundDifferent = true
+			break
+		}
+	}
+
+	if !foundDifferent {
+		t.Error("Generator produced same selection 10 times")
+	}
+}
+
+func intSliceContains(slice []int, val int) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}
+
+func intSliceIndex(slice []int, val int) int {
+	for i, item := range slice {
+		if item == val {
+			return i
+		}
+	}
+	return -1
+}

--- a/gen/shuffle.go
+++ b/gen/shuffle.go
@@ -1,0 +1,43 @@
+package gen
+
+import (
+	"reflect"
+
+	"github.com/leanovate/gopter"
+)
+
+// Shuffle takes a slice and returns a generator that produces shuffled copies
+// Example: Shuffle([]int{1,2,3}) might produce []int{3,1,2} or []int{2,3,1}
+// Note: This generator has no shrinker. Use small slices to keep failing test feedback readable.
+func Shuffle(items interface{}) gopter.Gen {
+	itemsVal := reflect.ValueOf(items)
+	if itemsVal.Kind() != reflect.Slice {
+		panic("Shuffle requires a slice")
+	}
+
+	n := itemsVal.Len()
+	sliceType := itemsVal.Type()
+
+	if n == 0 {
+		return Const(reflect.MakeSlice(sliceType, 0, 0).Interface())
+	}
+	if n == 1 {
+		return Const(items)
+	}
+
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		result := reflect.MakeSlice(sliceType, n, n)
+		for i := 0; i < n; i++ {
+			result.Index(i).Set(itemsVal.Index(i))
+		}
+
+		for i := n - 1; i > 0; i-- {
+			j := genParams.Rng.Intn(i + 1)
+			tmp := result.Index(i).Interface()
+			result.Index(i).Set(result.Index(j))
+			result.Index(j).Set(reflect.ValueOf(tmp))
+		}
+
+		return gopter.NewGenResult(result.Interface(), gopter.NoShrinker)
+	}
+}

--- a/gen/shuffle_test.go
+++ b/gen/shuffle_test.go
@@ -1,0 +1,120 @@
+package gen_test
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/leanovate/gopter/gen"
+)
+
+func TestShuffle(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	shuffleGen := gen.Shuffle(items)
+
+	for i := 0; i < 100; i++ {
+		value, ok := shuffleGen.Sample()
+		if !ok {
+			t.Error("Sample was not ok")
+			continue
+		}
+
+		result, ok := value.([]int)
+		if !ok {
+			t.Errorf("Sample not slice of int: %#v", value)
+			continue
+		}
+
+		if len(result) != len(items) {
+			t.Errorf("Expected length %d, got %d: %v", len(items), len(result), result)
+			continue
+		}
+
+		sortedOriginal := make([]int, len(items))
+		copy(sortedOriginal, items)
+		sort.Ints(sortedOriginal)
+
+		sortedResult := make([]int, len(result))
+		copy(sortedResult, result)
+		sort.Ints(sortedResult)
+
+		if !reflect.DeepEqual(sortedOriginal, sortedResult) {
+			t.Errorf("Shuffled slice does not contain same elements as original.\nOriginal (sorted): %v\nResult (sorted): %v",
+				sortedOriginal, sortedResult)
+		}
+	}
+}
+
+func TestShuffleEmpty(t *testing.T) {
+	commonGeneratorTest(t, "shuffle empty", gen.Shuffle([]int{}), func(value interface{}) bool {
+		result, ok := value.([]int)
+		return ok && len(result) == 0
+	})
+}
+
+func TestShuffleSingle(t *testing.T) {
+	commonGeneratorTest(t, "shuffle single", gen.Shuffle([]int{42}), func(value interface{}) bool {
+		result, ok := value.([]int)
+		return ok && len(result) == 1 && result[0] == 42
+	})
+}
+
+func TestShuffleVariety(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	gen := gen.Shuffle(items)
+
+	first, ok := gen.Sample()
+	if !ok {
+		t.Fatal("First sample failed")
+	}
+	firstSlice := first.([]int)
+
+	foundDifferent := false
+	for i := 0; i < 10; i++ {
+		sample, ok := gen.Sample()
+		if !ok {
+			t.Fatal("Sample failed")
+		}
+		slice := sample.([]int)
+		if !reflect.DeepEqual(slice, firstSlice) {
+			foundDifferent = true
+			break
+		}
+	}
+
+	if !foundDifferent {
+		t.Error("Generator produced same ordering 10 times")
+	}
+}
+
+func TestShuffleDeterministic(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5}
+	shuffleGen := gen.Shuffle(items)
+
+	for seed := int64(0); seed < 100; seed++ {
+		params1 := fixedParameters(10, seed)
+		params2 := fixedParameters(10, seed)
+
+		result, ok := shuffleGen(params1).Retrieve()
+		if !ok {
+			t.Fatalf("Sample failed for seed %d", seed)
+		}
+		result1Slice, ok := result.([]int)
+		if !ok {
+			t.Fatalf("Result 1 not slice for seed %d: %#v", seed, result)
+		}
+
+		result, ok = shuffleGen(params2).Retrieve()
+		if !ok {
+			t.Fatalf("Sample failed for seed %d", seed)
+		}
+		result2Slice, ok := result.([]int)
+		if !ok {
+			t.Fatalf("Result 2 not slice for seed %d: %#v", seed, result)
+		}
+
+		if !reflect.DeepEqual(result1Slice, result2Slice) {
+			t.Errorf("Same seed produced different results for seed %d:\nSeed %d result 1: %v\nSeed %d result 2: %v", seed, seed, result1Slice, seed, result2Slice)
+		}
+	}
+}


### PR DESCRIPTION
This adds 2 new generators:
- `PickN(slice, number)` generates a new slice of randomly-selected `number` (up to `len(slice)`) items from (`slice`) in the same order with no duplicates
- `Shuffle(slice)` generates a new slice with all items from `slice` in random order

Tests inspired by the existing generators'.

Neither generators have shrinker, as explained in their godoc, as the shrinking strategy is not obvious and the generators are intended to work on small slices.

Originally designed for go 1.22 and retrofitted to work with go 1.12