### PR TITLE
fix: use range-aware shrinker in Int64Range to stay within bounds

### DIFF
--- a/gen/integers.go
+++ b/gen/integers.go
@@ -21,7 +21,7 @@ func Int64Range(min, max int64) gopter.Gen {
 	rangeSize := uint64(max - min + 1)
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		var nextResult = uint64(min) + (genParams.NextUint64() % rangeSize)
-		genResult := gopter.NewGenResult(int64(nextResult), Int64Shrinker)
+		genResult := gopter.NewGenResult(int64(nextResult), int64RangeShrinker(min, max))
 		genResult.Sieve = func(v interface{}) bool {
 			return v.(int64) >= min && v.(int64) <= max
 		}

--- a/gen/integers_shrink.go
+++ b/gen/integers_shrink.go
@@ -93,3 +93,33 @@ func IntShrinker(v interface{}) gopter.Shrink {
 func UIntShrinker(v interface{}) gopter.Shrink {
 	return UInt64Shrinker(uint64(v.(uint))).Map(uint64ToUint)
 }
+
+// int64RangeShrinker returns a shrinker that shrinks toward min, staying within [min, max].
+func int64RangeShrinker(min, max int64) gopter.Shrinker {
+	return func(v interface{}) gopter.Shrink {
+		value := v.(int64)
+		if value <= min {
+			return gopter.NoShrink
+		}
+		// Shrink toward min by halving the distance
+		shrink := int64Shrink{
+			original: value - min,
+			half:     (value - min) / 2,
+		}
+		return func() (interface{}, bool) {
+			candidate, ok := shrink.Next()
+			if !ok {
+				return nil, false
+			}
+			// Convert from distance-from-min back to actual value
+			result := value - candidate.(int64)
+			if result < min {
+				result = min
+			}
+			if result > max {
+				return nil, false
+			}
+			return result, true
+		}
+	}
+}


### PR DESCRIPTION
Fixes #81

## Problem

`gen.IntRange(min, max)` uses the generic `Int64Shrinker` which shrinks toward 0. When the range doesn't include 0 (e.g., `IntRange(5, 10)`), the shrinker produces values outside the range during shrinking.

While the `Sieve` filters these out in some contexts, stateful command-based tests may not apply the sieve during the shrink phase, causing panics from out-of-bounds values.

## Fix

Add a range-aware `int64RangeShrinker(min, max)` that shrinks toward `min` by halving the distance from `min`, guaranteeing all shrunk values stay within `[min, max]`.

All existing tests pass with `-race`.